### PR TITLE
PULL - SVCperm.vbs, REF #2 , FIXES #31

### DIFF
--- a/SVCperm.vbs
+++ b/SVCperm.vbs
@@ -151,6 +151,7 @@ elseif (errRET = 0) then
     if (err.number <> 0) then
       call LOGERR(4)
     end if
+    intSID = intSID + 1
   next
   ''APPLY NEW SECURITY DATABASE CONFIGS , 'ERRRET'=5
   call HOOK("secedit /import /db secedit.sdb /cfg c:\temp\config.inf")

--- a/version.xml
+++ b/version.xml
@@ -25,7 +25,7 @@
 	<reboot_force.vbs>1</reboot_force.vbs>
 	<reprobe.vbs>9</reprobe.vbs>
 	<SNMPparam.vbs>4</SNMPparam.vbs>
-	<SVCperm.vbs>8</SVCperm.vbs>
+	<SVCperm.vbs>9</SVCperm.vbs>
 	<sysnfo.vbs>1</sysnfo.vbs>
 	<VSS_Fix.vbs>1</VSS_Fix.vbs>
 	<wmi_disk.vbs>1</wmi_disk.vbs>


### PR DESCRIPTION
UPDATE #31 


Description : 
Update to Modify Config.inf for Local and Domain user if user exists at both levels.
SVCperm.vbs will collect enumerated users matching 'strUSR' target user and loop through adding each to exported security database 'config.inf' using array 'arrSID'

Changes : 
SVCperm.vbs, REF #2 , FIXES #31
 - Changes SVCperm.vbs script version 'strVER' from 8 to 9
 - Code Comment refinement
 - Moved call HOOK("secedit /export") to above 'for...next'' loop to edit security database with both Local and Domain 'strUSR' target user variants prior to call HOOK("secedit /import") and call HOOK("secedit /configure")

version.xml
 - Changed SVCperm.vbs script version from 8 to 9
 - Current Branch : 'dev'


Current Branch : dev


Propsed Branch : master


@CW-Khristos
