### PR TITLE
dev - Update SVCperm.vbs , REF #2 , FIXES #37

### DIFF
--- a/MSP Backups/MSP_Update.vbs
+++ b/MSP Backups/MSP_Update.vbs
@@ -78,8 +78,8 @@ if (((instr(1, strIDL, "Idle")) or (instr(1, strIDL, "RegSync")) or (strIDL = vb
   objLOG.write vbnewline & now & vbtab & " - INSTALLING LATEST MSP BACKUP CLIENT"
   call HOOK("C:\temp\mxb-windows-x86_x64.exe")
 elseif ((instr(1, strIDL, "Idle") = 0) and (instr(1, strIDL, "RegSync") = 0)) then    ''BACKUPS IN PROGRESS , 'ERRRET'=1
-  objOUT.write vbnewline & now & vbtab & vbtab & " - BACKUPS IN PROGRESS, ENDING MSP_ROTATE"
-  objLOG.write vbnewline & now & vbtab & vbtab & " - BACKUPS IN PROGRESS, ENDING MSP_ROTATE"
+  objOUT.write vbnewline & now & vbtab & vbtab & " - BACKUPS IN PROGRESS, ENDING MSP_UPDATE"
+  objLOG.write vbnewline & now & vbtab & vbtab & " - BACKUPS IN PROGRESS, ENDING MSP_UPDATE"
   call LOGERR(1)
 end if
 ''END SCRIPT

--- a/SVCperm.vbs
+++ b/SVCperm.vbs
@@ -16,7 +16,7 @@ dim strUSR, strPWD, strSVC
 dim objIN, objOUT, objARG, objWSH, objFSO
 dim objLOG, objEXEC, objHOOK, objSIN, objSOUT
 ''VERSION FOR SCRIPT UPDATE, SVCPERM.VBS, REF #2 , FIXES #21 , FIXES #31
-strVER = 9
+strVER = 10
 ''DEFAULT SUCCESS
 errRET = 0
 ''STDIN / STDOUT
@@ -97,10 +97,20 @@ elseif (errRET = 0) then
   objLOG.write vbnewline & vbnewline & now & vbtab & vbtab & " - COLLECTED USERNAMES AND SIDS"
   for intUSR = 0 to ubound(colUSR)
     ''FIND USER/S MATCHING PASSED 'STRUSR' TARGET USER
-    if (instr(1, lcase(colUSR(intUSR)), lcase(strUSR))) then
-      intSID = intSID + 1
-      arrSID(ubound(arrSID)) = colSID(intUSR)
-      redim arrSID(intSID)
+    ''HANDLE '\' IS PASSED TARGET USERNAME 'STRUSR' , REF #37
+    if (instr(1, lcase(strUSR), "\")) then
+      if (instr(1, lcase(colUSR(intUSR)), lcase(split(strUSR, "\")(1)))) then
+        intSID = intSID + 1
+        arrSID(ubound(arrSID)) = colSID(intUSR)
+        redim arrSID(intSID)
+      end if
+    ''HANDLE WITHOUT '\' IN PASSED TARGET USERNAME 'STRUSR' , REF #37
+    elseif (instr(1, lcase(strUSR), "\") = 0) then
+      if (instr(1, lcase(colUSR(intUSR)), strUSR)) then
+        intSID = intSID + 1
+        arrSID(ubound(arrSID)) = colSID(intUSR)
+        redim arrSID(intSID)
+      end if
     end if
     objOUT.write vbnewline & now & vbtab & vbtab & vbtab & colUSR(intUSR) & " : " & colSID(intUSR)
     objLOG.write vbnewline & now & vbtab & vbtab & vbtab & colUSR(intUSR) & " : " & colSID(intUSR)

--- a/SVCperm.vbs
+++ b/SVCperm.vbs
@@ -234,7 +234,7 @@ sub CHKAU()																					        ''CHECK FOR SCRIPT UPDATE , 'ERRRET'=10 
 	''FORCE SYNCHRONOUS
 	objXML.async = false
 	''LOAD SCRIPT VERSIONS DATABASE XML
-	if objXML.load("https://github.com/CW-Khristos/scripts/raw/dev/version.xml") then
+	if objXML.load("https://github.com/CW-Khristos/scripts/raw/master/version.xml") then
 		set colVER = objXML.documentelement
 		for each objSCR in colVER.ChildNodes
 			''LOCATE CURRENTLY RUNNING SCRIPT
@@ -244,7 +244,7 @@ sub CHKAU()																					        ''CHECK FOR SCRIPT UPDATE , 'ERRRET'=10 
 					objOUT.write vbnewline & now & " - UPDATING " & objSCR.nodename & " : " & objSCR.text & vbnewline
 					objLOG.write vbnewline & now & " - UPDATING " & objSCR.nodename & " : " & objSCR.text & vbnewline
 					''DOWNLOAD LATEST VERSION OF SCRIPT
-					call FILEDL("https://github.com/CW-Khristos/scripts/raw/dev/SVCperm.vbs", wscript.scriptname)
+					call FILEDL("https://github.com/CW-Khristos/scripts/raw/master/SVCperm.vbs", wscript.scriptname)
 					''RUN LATEST VERSION
 					if (wscript.arguments.count > 0) then             ''ARGUMENTS WERE PASSED
 						for x = 0 to (wscript.arguments.count - 1)

--- a/SVCperm.vbs
+++ b/SVCperm.vbs
@@ -100,16 +100,20 @@ elseif (errRET = 0) then
     ''HANDLE '\' IS PASSED TARGET USERNAME 'STRUSR' , REF #37
     if (instr(1, lcase(strUSR), "\")) then
       if (instr(1, lcase(colUSR(intUSR)), lcase(split(strUSR, "\")(1)))) then
+        redim preserve arrSID(intSID + 1)
+        arrSID(intSID) = colSID(intUSR)
         intSID = intSID + 1
-        arrSID(ubound(arrSID)) = colSID(intUSR)
-        redim arrSID(intSID)
+    objOUT.write vbnewline & now & vbtab & vbtab & vbtab & "MARKED : " & colUSR(intUSR) & " : " & arrSID(intSID - 1)
+    objLOG.write vbnewline & now & vbtab & vbtab & vbtab & "MARKED : " & colUSR(intUSR) & " : " & arrSID(intSID - 1)
       end if
     ''HANDLE WITHOUT '\' IN PASSED TARGET USERNAME 'STRUSR' , REF #37
     elseif (instr(1, lcase(strUSR), "\") = 0) then
-      if (instr(1, lcase(colUSR(intUSR)), strUSR)) then
+      if (instr(1, lcase(colUSR(intUSR)), lcase(strUSR))) then
+        redim preserve arrSID(intSID + 1)
+        arrSID(intSID) = colSID(intUSR)
         intSID = intSID + 1
-        arrSID(ubound(arrSID)) = colSID(intUSR)
-        redim arrSID(intSID)
+    objOUT.write vbnewline & now & vbtab & vbtab & vbtab & "MARKED : " & colUSR(intUSR) & " : " & arrSID(intSID - 1)
+    objLOG.write vbnewline & now & vbtab & vbtab & vbtab & "MARKED : " & colUSR(intUSR) & " : " & arrSID(intSID - 1)
       end if
     end if
     objOUT.write vbnewline & now & vbtab & vbtab & vbtab & colUSR(intUSR) & " : " & colSID(intUSR)
@@ -126,9 +130,12 @@ elseif (errRET = 0) then
   ''ENUMERATE THROUGH EACH USER COLLECTED MATCHING 'STRUSR' TARGET USER , REF#2 , FIXES #31
   ''THIS ALLOWS FOR TARGETING BOTH LOCAL AND DOMAIN USER VARIANTS
   for intSID = 0 to ubound(arrSID)
+    objOUT.write vbnewline & vbtab & vbtab & arrSID(intSID)
+  next
+  for intSID = 0 to ubound(arrSID)
+    strORG = "SeServiceLogonRight = "
     objOUT.write vbnewline & now & vbtab & vbtab & " - GRANT LOGON AS SERVICE : " & strUSR & " : " & arrSID(intSID)
     objLOG.write vbnewline & now & vbtab & vbtab & " - GRANT LOGON AS SERVICE : " & strUSR & " : " & arrSID(intSID)
-    strORG = "SeServiceLogonRight = "
     if (arrSID(intSID) <> vbnullstring) then          ''MATCHING USER SID FOUND
       strREP = "SeServiceLogonRight = " & "*" & arrSID(intSID) & ","
     elseif (arrSID(intSID) = vbnullstring) then       ''NO MATCHING USER SID FOUND , USE 'PLAINTEXT' USER NAME
@@ -161,7 +168,6 @@ elseif (errRET = 0) then
     if (err.number <> 0) then
       call LOGERR(4)
     end if
-    intSID = intSID + 1
   next
   ''APPLY NEW SECURITY DATABASE CONFIGS , 'ERRRET'=5
   call HOOK("secedit /import /db secedit.sdb /cfg c:\temp\config.inf")

--- a/SVCperm.vbs
+++ b/SVCperm.vbs
@@ -126,8 +126,8 @@ elseif (errRET = 0) then
   ''ENUMERATE THROUGH EACH USER COLLECTED MATCHING 'STRUSR' TARGET USER , REF#2 , FIXES #31
   ''THIS ALLOWS FOR TARGETING BOTH LOCAL AND DOMAIN USER VARIANTS
   for intSID = 0 to ubound(arrSID)
-    objOUT.write vbnewline & now & vbtab & vbtab & " - GRANT LONGON AS SERVICE : " & strUSR & " : " & arrSID(intSID)
-    objLOG.write vbnewline & now & vbtab & vbtab & " - GRANT LONGON AS SERVICE : " & strUSR & " : " & arrSID(intSID)
+    objOUT.write vbnewline & now & vbtab & vbtab & " - GRANT LOGON AS SERVICE : " & strUSR & " : " & arrSID(intSID)
+    objLOG.write vbnewline & now & vbtab & vbtab & " - GRANT LOGON AS SERVICE : " & strUSR & " : " & arrSID(intSID)
     strORG = "SeServiceLogonRight = "
     if (arrSID(intSID) <> vbnullstring) then          ''MATCHING USER SID FOUND
       strREP = "SeServiceLogonRight = " & "*" & arrSID(intSID) & ","

--- a/version.xml
+++ b/version.xml
@@ -25,7 +25,7 @@
 	<reboot_force.vbs>1</reboot_force.vbs>
 	<reprobe.vbs>9</reprobe.vbs>
 	<SNMPparam.vbs>4</SNMPparam.vbs>
-	<SVCperm.vbs>9</SVCperm.vbs>
+	<SVCperm.vbs>10</SVCperm.vbs>
 	<sysnfo.vbs>1</sysnfo.vbs>
 	<VSS_Fix.vbs>1</VSS_Fix.vbs>
 	<wmi_disk.vbs>1</wmi_disk.vbs>


### PR DESCRIPTION
UPDATE #37 

Description : 
SVCperm.vbs is not successfully mapping passed user account and existing SID

Changes : 
[SVCperm.vbs](https://github.com/CW-Khristos/scripts/blob/dev/SVCperm.vbs) , REF #2 , REF #37
 - https://github.com/CW-Khristos/scripts/commit/66e3ba52d9a401189ecf2c880f38bace973cf58c
   - Changed 'strVER' from 9 to 10
   - Added input validation for 'strUSR' to check for '\' in passed username; this should handle and correct username / SID mapping issue in call HOOK('"secedit") on Ln 157-158 (now 167-168)
 - https://github.com/CW-Khristos/scripts/commit/180b77d10db38ffd767477169b58e24bac0d5cfe
   - Corrected redim of 'arrSID' and moved to prior to variable assignment
   - Removed increment of 'intSID' at Ln 164; caused "skipping" of 'arrSID' elements
   - Verified FIXES #37
 - https://github.com/CW-Khristos/scripts/commit/adf4d21802b49f97f73aba86ab70142ede4f8f6c
   - Changed CHKAU() download link to 'master' Branch

Current Branch : dev

Propsed Branch : master

@CW-Khristos
